### PR TITLE
docs: Add package description for ember-observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-url-hash-polyfill",
   "version": "1.0.11",
-  "description": "The default blueprint for ember-cli addons.",
+  "description": "Support for in/inter page linking / scrolling with hashes in EmberJS.",
   "keywords": [
     "ember-addon"
   ],


### PR DESCRIPTION
- As per [this conversation](https://discord.com/channels/480462759797063690/1201801090073624607/1201978338433044510) the addon won't show up in full-text search on [Ember Observer](https://emberobserver.com/?query=Support%20for%20in%2Finter%20page%20linking%20%2F%20scrolling%20with%20hashes%20in%20EmberJS) because it's missing `description` field in `package.json`